### PR TITLE
Replace --debug option with --silent, enable debug output by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,7 @@ jobs:
           $(bundle exec split-test-rb \
             --xml-path tmp/rspec-results.xml \
             --node-index ${{ matrix.node_index }} \
-            --node-total 10 \
-            --debug)
+            --node-total 10)
 
     - name: Upload test results
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ split-test-rb --xml-path rspec-results.xml --node-index 0 --node-total 4
 - `--xml-path PATH` - Path to JUnit XML report (required)
 - `--node-index INDEX` - Current node index, 0-based (default: 0)
 - `--node-total TOTAL` - Total number of nodes (default: 1)
-- `--debug` - Show debug information with distribution details
+- `--silent` - Hide debug information (debug information is shown by default)
 - `-h, --help` - Show help message
 
 ### Example with RSpec
@@ -47,12 +47,12 @@ split-test-rb --xml-path rspec-results.xml --node-index 0 --node-total 4
 bundle exec rspec $(split-test-rb --xml-path rspec-results.xml --node-index 0 --node-total 4)
 ```
 
-### Debug Mode
+### Debug Information
 
-Use `--debug` to see how tests are distributed:
+By default, test distribution information is displayed to stderr:
 
 ```bash
-split-test-rb --xml-path rspec-results.xml --node-total 4 --debug
+split-test-rb --xml-path rspec-results.xml --node-total 4
 ```
 
 Output:
@@ -66,6 +66,12 @@ Node 1: 6 files, 12.45s total
   - spec/models/post_spec.rb
   ...
 =========================
+```
+
+Use `--silent` to hide this information:
+
+```bash
+split-test-rb --xml-path rspec-results.xml --node-total 4 --silent
 ```
 
 ## GitHub Actions Example

--- a/lib/split_test_rb.rb
+++ b/lib/split_test_rb.rb
@@ -83,7 +83,7 @@ module SplitTestRb
       # Balance tests across nodes
       nodes = Balancer.balance(timings, options[:total_nodes])
 
-      if options[:debug]
+      unless options[:silent]
         print_debug_info(nodes)
       end
 
@@ -96,7 +96,7 @@ module SplitTestRb
       options = {
         node_index: 0,
         total_nodes: 1,
-        debug: false
+        silent: false
       }
 
       OptionParser.new do |opts|
@@ -114,8 +114,8 @@ module SplitTestRb
           options[:xml_path] = v
         end
 
-        opts.on('--debug', 'Show debug information') do
-          options[:debug] = true
+        opts.on('--silent', 'Hide debug information') do
+          options[:silent] = true
         end
 
         opts.on('-h', '--help', 'Show this help message') do

--- a/spec/split_test_rb/cli_spec.rb
+++ b/spec/split_test_rb/cli_spec.rb
@@ -77,16 +77,16 @@ RSpec.describe SplitTestRb::CLI do
       expect(options[:xml_path]).to eq('test.xml')
     end
 
-    it 'parses debug flag' do
-      options = described_class.parse_options(['--debug'])
-      expect(options[:debug]).to be true
+    it 'parses silent flag' do
+      options = described_class.parse_options(['--silent'])
+      expect(options[:silent]).to be true
     end
 
     it 'sets default values' do
       options = described_class.parse_options([])
       expect(options[:node_index]).to eq(0)
       expect(options[:total_nodes]).to eq(1)
-      expect(options[:debug]).to be false
+      expect(options[:silent]).to be false
     end
   end
 


### PR DESCRIPTION
## Summary

This PR changes the CLI behavior to show debug information by default and introduces a `--silent` option to hide it instead.

### Changes
- Replace `--debug` flag with `--silent` flag in CLI (lib/split_test_rb.rb)
- Update default behavior: debug information is now shown by default
- Update all tests to use `--silent` option instead of `--debug` (spec/split_test_rb/cli_spec.rb)
- Update README.md with new option documentation
- Remove `--debug` from CI workflow since debug output is now default (.github/workflows/ci.yml)

### Rationale
- Debug information is useful for understanding test distribution in CI logs
- Users who want clean output can use `--silent` to suppress it
- More intuitive default behavior for debugging parallel test runs

## Test Plan
- [ ] All existing tests pass
- [ ] `--silent` option correctly hides debug output
- [ ] Default behavior shows debug information
- [ ] CI workflow runs successfully with new default behavior