### PR TITLE
Improve test distribution for first PR run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,15 @@ jobs:
         ruby-version: '3.3'
         bundler-cache: true
 
+    # Restore previous test results for optimal test distribution
+    # Priority: 1) Current branch cache, 2) Main branch cache (for first PR run), 3) Any other branch
     - name: Restore previous test results from cache
       uses: actions/cache/restore@v4
       with:
         path: tmp/rspec-results.xml
         key: rspec-results-${{ github.ref }}
         restore-keys: |
+          rspec-results-refs/heads/main
           rspec-results-
 
     - name: Run tests with split-test-rb


### PR DESCRIPTION
## Summary

Improve parallel test distribution on first PR run by using main branch cache as fallback.

## Changes

- Add `rspec-results-refs/heads/main` to `restore-keys` in cache restore step (.github/workflows/ci.yml)
- Add comments explaining cache priority and fallback strategy

## Problem

Previously, when creating a new PR, the first run had no cache available, so tests were distributed with equal weights (1.0s per file) instead of using historical execution times. This resulted in suboptimal test distribution on the first run.

## Solution

Use main branch's test results as fallback. Now the cache resolution works as:
1. Current branch cache (for 2nd+ runs)
2. Main branch cache (for first PR run)
3. Any other branch cache (final fallback)

This ensures optimal test distribution from the first PR run.