### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Maintain dependencies for Bundler
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated dependency updates
- Monitor Bundler dependencies (Ruby gems) with weekly checks
- Monitor GitHub Actions with weekly checks
- Group development dependencies to reduce PR noise

## Details
**Bundler updates:**
- Weekly schedule
- Groups development dependencies for minor/patch updates
- Allows up to 10 open PRs

**GitHub Actions updates:**
- Weekly schedule
- Monitors actions like checkout, setup-ruby, codecov, etc.
- Allows up to 5 open PRs