### PR TITLE
Add execution time and default indicator to test distribution output

### DIFF
--- a/lib/split_test_rb.rb
+++ b/lib/split_test_rb.rb
@@ -1,5 +1,6 @@
 require 'nokogiri'
 require 'optparse'
+require 'set'
 
 module SplitTestRb
   # Parses JUnit XML files and extracts test timing data
@@ -59,6 +60,7 @@ module SplitTestRb
       end
 
       # Parse JUnit XML and get timings, or use all spec files if XML doesn't exist
+      default_files = Set.new
       if File.exist?(options[:xml_path])
         timings = JunitParser.parse(options[:xml_path])
         # Find all spec files and add any missing ones with default weight
@@ -68,11 +70,13 @@ module SplitTestRb
           warn "Warning: Found #{missing_files.size} spec files not in XML, adding with default weight"
           missing_files.each do |file|
             timings[file] = 1.0
+            default_files.add(file)
           end
         end
       else
         warn "Warning: XML file not found: #{options[:xml_path]}, using all spec files with equal weights"
         timings = find_all_spec_files
+        default_files = Set.new(timings.keys)
       end
 
       if timings.empty?
@@ -84,7 +88,7 @@ module SplitTestRb
       nodes = Balancer.balance(timings, options[:total_nodes])
 
       if options[:debug]
-        print_debug_info(nodes)
+        print_debug_info(nodes, timings, default_files)
       end
 
       # Output files for the specified node
@@ -134,12 +138,16 @@ module SplitTestRb
       spec_files.each_with_object({}) { |file, hash| hash[file] = 1.0 }
     end
 
-    def self.print_debug_info(nodes)
+    def self.print_debug_info(nodes, timings, default_files)
       warn '=== Test Distribution ==='
       nodes.each_with_index do |node, index|
         warn "Node #{index}: #{node[:files].size} files, #{node[:total_time].round(2)}s total"
         node[:files].each do |file|
-          warn "  - #{file}"
+          time = timings[file]
+          time_str = "(#{time.round(2)}s"
+          time_str += ', default' if default_files.include?(file)
+          time_str += ')'
+          warn "  - #{file} #{time_str}"
         end
       end
       warn '========================='

--- a/spec/split_test_rb/cli_spec.rb
+++ b/spec/split_test_rb/cli_spec.rb
@@ -176,14 +176,41 @@ RSpec.describe SplitTestRb::CLI do
         { files: ['spec/a_spec.rb', 'spec/b_spec.rb'], total_time: 5.5 },
         { files: ['spec/c_spec.rb'], total_time: 3.2 }
       ]
+      timings = {
+        'spec/a_spec.rb' => 3.0,
+        'spec/b_spec.rb' => 2.5,
+        'spec/c_spec.rb' => 3.2
+      }
+      default_files = Set.new
 
       output = capture_stderr do
-        described_class.print_debug_info(nodes)
+        described_class.print_debug_info(nodes, timings, default_files)
       end
 
       expect(output).to match(/Test Distribution/)
       expect(output).to match(/Node 0: 2 files, 5\.5s total/)
       expect(output).to match(/Node 1: 1 files, 3\.2s total/)
+      expect(output).to match(/spec\/a_spec\.rb \(3\.0s\)/)
+      expect(output).to match(/spec\/b_spec\.rb \(2\.5s\)/)
+      expect(output).to match(/spec\/c_spec\.rb \(3\.2s\)/)
+    end
+
+    it 'marks default files in debug output' do
+      nodes = [
+        { files: ['spec/a_spec.rb', 'spec/b_spec.rb'], total_time: 2.0 }
+      ]
+      timings = {
+        'spec/a_spec.rb' => 1.0,
+        'spec/b_spec.rb' => 1.0
+      }
+      default_files = Set.new(['spec/b_spec.rb'])
+
+      output = capture_stderr do
+        described_class.print_debug_info(nodes, timings, default_files)
+      end
+
+      expect(output).to match(/spec\/a_spec\.rb \(1\.0s\)/)
+      expect(output).to match(/spec\/b_spec\.rb \(1\.0s, default\)/)
     end
   end
 


### PR DESCRIPTION
- Display execution time next to each file in debug output
- Mark files using default weight (1.0s) with '(default)' label
- Track default files using Set for efficient lookup
- Update tests to verify new output format