### PR TITLE
Support loading multiple JUnit XML files from directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Restore previous test results from cache
       uses: actions/cache/restore@v5
       with:
-        path: tmp/rspec-results.xml
+        path: tmp/cache/
         key: rspec-results-${{ github.ref }}
         restore-keys: |
           rspec-results-refs/heads/main
@@ -71,13 +71,13 @@ jobs:
 
     - name: Run tests with split-test-rb
       run: |
-        mkdir -p tmp
+        mkdir -p tmp/results
         bundle exec rspec \
           --format progress \
           --format RspecJunitFormatter \
-          --out tmp/rspec-results-${{ matrix.node_index }}.xml \
+          --out tmp/results/rspec-results-${{ matrix.node_index }}.xml \
           $(bundle exec split-test-rb \
-            --xml-path tmp/rspec-results.xml \
+            --xml-path tmp/cache \
             --node-index ${{ matrix.node_index }} \
             --node-total 5 \
             --debug)
@@ -87,7 +87,7 @@ jobs:
       if: always()
       with:
         name: rspec-results-node-${{ matrix.node_index }}
-        path: tmp/rspec-results-${{ matrix.node_index }}.xml
+        path: tmp/results/rspec-results-${{ matrix.node_index }}.xml
 
   merge-test-results:
     runs-on: ubuntu-latest
@@ -103,19 +103,14 @@ jobs:
         path: tmp/results/
         merge-multiple: true
 
-    - name: Merge test results
-      run: |
-        # Merge all XML files into one for next run
-        cat tmp/results/rspec-results-*.xml > tmp/rspec-results.xml || echo "<testsuites></testsuites>" > tmp/rspec-results.xml
-
     - name: Upload merged test results
       uses: actions/upload-artifact@v6
       with:
-        name: rspec-results
-        path: tmp/rspec-results.xml
+        name: rspec-results-all
+        path: tmp/results/
 
     - name: Save test results to cache for next run
       uses: actions/cache/save@v5
       with:
-        path: tmp/rspec-results.xml
+        path: tmp/results/
         key: rspec-results-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ split-test-rb --xml-path rspec-results.xml --node-index 0 --node-total 4
 
 ### Options
 
-- `--xml-path PATH` - Path to JUnit XML report (required)
+- `--xml-path PATH` - Path to JUnit XML report file or directory containing XML files (required)
 - `--node-index INDEX` - Current node index, 0-based (default: 0)
 - `--node-total TOTAL` - Total number of nodes (default: 1)
 - `--debug` - Show debug information with distribution details
@@ -82,7 +82,10 @@ This project has real running example:
 
 ## How It Works
 
-1. **Parse JUnit XML**: Extracts test file paths and execution times from the XML report
+1. **Parse JUnit XML**: Extracts test file paths and execution times from XML report(s)
+   - Accepts a single XML file or a directory containing multiple XML files
+   - When a directory is specified, all `.xml` files in that directory are processed
+   - Execution times are aggregated across all files
 2. **Greedy Balancing**: Sorts files by execution time (descending) and assigns each file to the node with the lowest cumulative time
 3. **Output**: Prints the list of test files for the specified node
 


### PR DESCRIPTION
CHANGES:
- Modified JunitParser to accept directory path in addition to file path
- When directory is specified, all .xml files are parsed and timings aggregated
- Updated CI workflow to store results in separate cache/results directories
- Removed invalid XML concatenation with cat command
- Added debug output showing which XML files are being loaded
- Added tests for directory parsing functionality
- Updated README to document directory support

FIXES:
- Fixes invalid XML generation from cat command merging multiple XML files
- CI now properly reads multiple XML reports without XML parsing errors

TECHNICAL DETAILS:
- JunitParser.parse now detects if path is directory or file
- New parse_file method handles individual XML file parsing
- CI separates cache (tmp/cache/) from current results (tmp/results/)
- Cache/restore workflow updated to use directory paths