### PR TITLE
Rename merge-test-results job to cache-test-results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         name: rspec-results-node-${{ matrix.node_index }}
         path: tmp/rspec-results/rspec-results-${{ matrix.node_index }}.xml
 
-  merge-test-results:
+  cache-test-results:
     runs-on: ubuntu-latest
     needs: parallel-test
     if: always()
@@ -103,7 +103,7 @@ jobs:
         path: tmp/rspec-results/
         merge-multiple: true
 
-    - name: Upload merged test results
+    - name: Upload test results
       uses: actions/upload-artifact@v6
       with:
         name: rspec-results


### PR DESCRIPTION
The job doesn't actually merge XML contents - it collects results
from parallel nodes and caches them for the next run.