### PR TITLE
Remove RSpec examples and debug instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Then run:
 bundle install
 ```
 
-## Usage
-
 ## GitHub Actions Example
 
 First, add split-test-rb to your Gemfile:


### PR DESCRIPTION
Removed RSpec usage examples and debug mode instructions from the README.