### PR TITLE
Clarify terminology: replace 'weight' with 'execution time'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ split-test-rb provides intelligent fallback handling to ensure tests can run eve
 
 ### When XML file doesn't exist
 If the specified XML file is not found, the tool will:
-- Display a warning: `Warning: XML file not found: <path>, using all spec files with equal weights`
+- Display a warning: `Warning: XML file not found: <path>, using all spec files with equal execution time`
 - Find all spec files matching `spec/**/*_spec.rb`
 - Assign equal execution time (1.0 seconds) to each file
 - Distribute them evenly across nodes
@@ -60,7 +60,7 @@ This is useful for:
 
 ### When spec files are missing from XML
 If new spec files exist that aren't in the XML report, the tool will:
-- Display a warning: `Warning: Found N spec files not in XML, adding with default weight`
+- Display a warning: `Warning: Found N spec files not in XML, adding with default execution time`
 - Add the missing files with default execution time (1.0 seconds)
 - Include them in the distribution
 

--- a/lib/split_test_rb.rb
+++ b/lib/split_test_rb.rb
@@ -96,18 +96,18 @@ module SplitTestRb
       xml_dir = options[:xml_path]
       if File.directory?(xml_dir)
         timings = JunitParser.parse_directory(xml_dir)
-        # Find all spec files and add any missing ones with default weight
+        # Find all spec files and add any missing ones with default execution time
         all_spec_files = find_all_spec_files
         missing_files = all_spec_files.keys - timings.keys
         unless missing_files.empty?
-          warn "Warning: Found #{missing_files.size} spec files not in XML, adding with default weight"
+          warn "Warning: Found #{missing_files.size} spec files not in XML, adding with default execution time"
           missing_files.each do |file|
             timings[file] = 1.0
             default_files.add(file)
           end
         end
       else
-        warn "Warning: XML directory not found: #{xml_dir}, using all spec files with equal weights"
+        warn "Warning: XML directory not found: #{xml_dir}, using all spec files with equal execution time"
         timings = find_all_spec_files
         default_files = Set.new(timings.keys)
       end
@@ -167,7 +167,7 @@ module SplitTestRb
     def self.find_all_spec_files
       # Find all spec files in the spec directory
       spec_files = Dir.glob('spec/**/*_spec.rb')
-      # Normalize paths and assign equal weight (1.0) to each file
+      # Normalize paths and assign equal execution time (1.0) to each file
       spec_files.each_with_object({}) do |file, hash|
         normalized_path = JunitParser.normalize_path(file)
         hash[normalized_path] = 1.0


### PR DESCRIPTION
The term 'weight' was ambiguous and confusing. Changed all references
to use 'execution time' instead, which clearly describes that we're
talking about test file execution duration in seconds.

Updated:
- Warning messages in lib/split_test_rb.rb
- Comments in lib/split_test_rb.rb
- Documentation in README.md