### PR TITLE
Remove defaults from test CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ Options:
   --node-index INDEX          Current node index (0-based)
   --node-total TOTAL          Total number of nodes
   --xml-path PATH             Path to directory containing JUnit XML reports (required)
-  --test-dir DIR              Test directory (default: spec)
-  --test-pattern PATTERN      Test file pattern (default: **/*_spec.rb)
+  --test-dir DIR              Test directory (required)
+  --test-pattern PATTERN      Test file pattern (required)
   --debug                     Show debug information
   -h, --help                  Show help message
 ```
 
 ### Custom Test Directory and Pattern
 
-By default, split-test-rb looks for test files in the `spec/` directory with the pattern `**/*_spec.rb`. You can customize this for projects with different test directory structures:
+You must specify the test directory and pattern for your project. This allows split-test-rb to work with different test frameworks and directory structures:
 
 **Using Minitest with `test/` directory:**
 ```bash
@@ -94,7 +94,7 @@ split-test-rb provides intelligent fallback handling to ensure tests can run eve
 ### When XML file doesn't exist
 If the specified XML file is not found, the tool will:
 - Display a warning: `Warning: XML directory not found: <path>, using all test files with equal execution time`
-- Find all test files matching the specified directory and pattern (default: `spec/**/*_spec.rb`)
+- Find all test files matching the specified directory and pattern
 - Assign equal execution time (1.0 seconds) to each file
 - Distribute them evenly across nodes
 

--- a/lib/split_test_rb.rb
+++ b/lib/split_test_rb.rb
@@ -91,6 +91,16 @@ module SplitTestRb
         exit 1
       end
 
+      unless options[:test_dir]
+        warn 'Error: --test-dir is required'
+        exit 1
+      end
+
+      unless options[:test_pattern]
+        warn 'Error: --test-pattern is required'
+        exit 1
+      end
+
       # Parse JUnit XML files from directory and get timings, or use all test files if directory doesn't exist
       default_files = Set.new
       xml_dir = options[:xml_path]
@@ -133,9 +143,7 @@ module SplitTestRb
       options = {
         node_index: 0,
         total_nodes: 1,
-        debug: false,
-        test_dir: 'spec',
-        test_pattern: '**/*_spec.rb'
+        debug: false
       }
 
       OptionParser.new do |opts|
@@ -153,11 +161,11 @@ module SplitTestRb
           options[:xml_path] = v
         end
 
-        opts.on('--test-dir DIR', 'Test directory (default: spec)') do |v|
+        opts.on('--test-dir DIR', 'Test directory (required)') do |v|
           options[:test_dir] = v
         end
 
-        opts.on('--test-pattern PATTERN', 'Test file pattern (default: **/*_spec.rb)') do |v|
+        opts.on('--test-pattern PATTERN', 'Test file pattern (required)') do |v|
           options[:test_pattern] = v
         end
 


### PR DESCRIPTION
Remove default values for --test-dir and --test-pattern to make them required options. This ensures users explicitly specify test directory and pattern for their project, improving clarity and preventing assumptions about project structure.

Changes:
- Remove 'spec' and '**/*_spec.rb' defaults from options hash
- Add validation to exit with error if options not provided
- Update help text to indicate options are required
- Update all CLI spec tests to provide these options
- Add tests to verify error messages when options are missing
- Update README to reflect required status