### PR TITLE
Update dependabot schedule to Saturday 7:00 JST

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
     groups:
       development-dependencies:
@@ -18,4 +21,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Dependabotの実行スケジュールを毎週土曜日 7:00 JST に変更

## Changes
- bundlerとgithub-actions両方のpackage-ecosystemに対してスケジュールを設定
  - `day: "saturday"`
  - `time: "07:00"`
  - `timezone: "Asia/Tokyo"`