### PR TITLE
Fix .rubocop.yml for rubocop-rspec v3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
 
 AllCops:
@@ -9,20 +9,6 @@ AllCops:
     - 'tmp/**/*'
     - 'coverage/**/*'
     - 'spec/split_test_rb/dummy_*.rb'
-
-# Disable cops from dependencies that are not used in this project
-# These are transitively included via rubocop-rspec but not applicable to this gem
-Capybara:
-  Enabled: false
-
-Capybara/RSpec/PredicateMatcher:
-  Enabled: false
-
-FactoryBot:
-  Enabled: false
-
-RSpecRails:
-  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes


### PR DESCRIPTION
## Summary
- Update `.rubocop.yml` to use `plugins:` instead of `require:` for rubocop-rspec (new plugin system in v3)
- Remove `Capybara`, `FactoryBot`, `RSpecRails` department configurations (these no longer exist in rubocop-rspec v3)

This fixes the CI failure in #33.