### PR TITLE
Add SonarQube configuration to ignore duplications in spec files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+# SonarQube Configuration
+sonar.projectKey=split-test-rb
+sonar.organization=split-test-rb
+
+# Source code directories
+sonar.sources=lib
+sonar.tests=spec
+
+# Exclude spec files from duplication detection
+sonar.cpd.exclusions=spec/**/*_spec.rb
+
+# Ruby language
+sonar.language=ruby
+
+# Encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Configure sonar.cpd.exclusions to exclude spec/**/*_spec.rb from
duplication detection. Test files often have similar patterns and
repetitive code that are acceptable in test suites.