### PR TITLE
Apply Metrics/AbcSize to spec files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,8 +29,6 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 25
-  Exclude:
-    - 'spec/**/*'
 
 Metrics/ClassLength:
   Max: 150


### PR DESCRIPTION
## Summary

- Remove `spec/**/*` from `Metrics/AbcSize` exclude list
- Apply Max: 25 limit to spec files (same as production code)

## Notes

No violations found in spec files - all files already comply with AbcSize <= 25.