### PR TITLE
Add RSpec standard JUnit formatter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 [![codecov](https://codecov.io/gh/naofumi-fujii/split-test-rb/branch/main/graph/badge.svg)](https://codecov.io/gh/naofumi-fujii/split-test-rb)
 
-A simple Ruby CLI tool to balance RSpec tests across parallel CI nodes using JUnit XML reports.
+A simple Ruby CLI tool to balance RSpec tests across parallel CI nodes using test timing data.
 
 ## Overview
 
-split-test-rb reads JUnit XML test reports containing execution times and distributes test files across multiple nodes for parallel execution. It uses a greedy algorithm to ensure balanced distribution based on historical test execution times.
+split-test-rb reads test reports containing execution times and distributes test files across multiple nodes for parallel execution. It uses a greedy algorithm to ensure balanced distribution based on historical test execution times.
+
+Supported formats:
+- RSpec JSON formatter (built-in, no gem required)
+- JUnit XML reports (via rspec_junit_formatter gem)
 
 ## Installation
 
@@ -46,12 +50,14 @@ split-test-rb [options]
 Options:
   --node-index INDEX          Current node index (0-based)
   --node-total TOTAL          Total number of nodes
-  --xml-path PATH             Path to directory containing JUnit XML reports (required)
+  --xml-path PATH             Path to directory containing test results (JUnit XML or RSpec JSON) (required)
   --test-dir DIR              Test directory (default: spec)
   --test-pattern PATTERN      Test file pattern (default: **/*_spec.rb)
   --debug                     Show debug information
   -h, --help                  Show help message
 ```
+
+Note: The tool auto-detects the format based on file extensions (.xml or .json) in the results directory.
 
 ### Custom Test Directory and Pattern
 
@@ -83,7 +89,7 @@ The test directory and pattern options are useful for:
 
 ## How It Works
 
-1. **Parse JUnit XML**: Extracts test file paths and execution times from the XML report
+1. **Parse Test Results**: Extracts test file paths and execution times from test reports (auto-detects JSON or XML format)
 2. **Greedy Balancing**: Sorts files by execution time (descending) and assigns each file to the node with the lowest cumulative time
 3. **Output**: Prints the list of test files for the specified node
 
@@ -91,9 +97,9 @@ The test directory and pattern options are useful for:
 
 split-test-rb provides intelligent fallback handling to ensure tests can run even without historical timing data:
 
-### When XML file doesn't exist
-If the specified XML file is not found, the tool will:
-- Display a warning: `Warning: XML directory not found: <path>, using all test files with equal execution time`
+### When results directory doesn't exist
+If the specified results directory is not found, the tool will:
+- Display a warning: `Warning: Results directory not found: <path>, using all test files with equal execution time`
 - Find all test files matching the specified directory and pattern (default: `spec/**/*_spec.rb`)
 - Assign equal execution time (1.0 seconds) to each file
 - Distribute them evenly across nodes
@@ -103,15 +109,57 @@ This is useful for:
 - Local development environments
 - New CI pipelines
 
-### When test files are missing from XML
-If new test files exist that aren't in the XML report, the tool will:
-- Display a warning: `Warning: Found N test files not in XML, adding with default execution time`
+### When test files are missing from results
+If new test files exist that aren't in the test results, the tool will:
+- Display a warning: `Warning: Found N test files not in JSON/XML, adding with default execution time`
 - Add the missing files with default execution time (1.0 seconds)
 - Include them in the distribution
 
 This ensures newly added test files are always included in the test run.
 
-## JUnit XML Format
+## Test Result Formats
+
+### RSpec JSON Format (Recommended)
+
+RSpec has a built-in JSON formatter that requires no additional gems. This is the recommended approach:
+
+**Configure in .rspec:**
+```
+--format json
+--out tmp/rspec-results.json
+```
+
+**Or use command line:**
+```bash
+bundle exec rspec --format json --out tmp/rspec-results.json
+```
+
+The JSON formatter outputs test timing data in the following structure:
+```json
+{
+  "examples": [
+    {
+      "file_path": "spec/models/user_spec.rb",
+      "run_time": 1.234
+    }
+  ]
+}
+```
+
+### JUnit XML Format (Alternative)
+
+Alternatively, you can use JUnit XML format with the `rspec_junit_formatter` gem:
+
+**Add to Gemfile:**
+```ruby
+gem 'rspec_junit_formatter'
+```
+
+**Configure in .rspec:**
+```
+--format RspecJunitFormatter
+--out tmp/rspec-results.xml
+```
 
 The tool expects JUnit XML with `file` or `filepath` attributes on testcase elements:
 
@@ -121,8 +169,6 @@ The tool expects JUnit XML with `file` or `filepath` attributes on testcase elem
   <testcase file="spec/models/post_spec.rb" time="0.567" />
 </testsuite>
 ```
-
-For RSpec, use the `rspec_junit_formatter` gem to generate compatible XML reports.
 
 ## License
 

--- a/spec/fixtures/sample_rspec.json
+++ b/spec/fixtures/sample_rspec.json
@@ -1,0 +1,104 @@
+{
+  "version": "3.13.0",
+  "seed": 12345,
+  "examples": [
+    {
+      "id": "./spec/models/user_spec.rb[1:1]",
+      "description": "validates presence of name",
+      "full_description": "User validates presence of name",
+      "status": "passed",
+      "file_path": "./spec/models/user_spec.rb",
+      "line_number": 3,
+      "run_time": 2.5
+    },
+    {
+      "id": "./spec/models/user_spec.rb[1:2]",
+      "description": "validates uniqueness of email",
+      "full_description": "User validates uniqueness of email",
+      "status": "passed",
+      "file_path": "./spec/models/user_spec.rb",
+      "line_number": 8,
+      "run_time": 1.8
+    },
+    {
+      "id": "./spec/models/post_spec.rb[1:1]",
+      "description": "belongs to user",
+      "full_description": "Post belongs to user",
+      "status": "passed",
+      "file_path": "./spec/models/post_spec.rb",
+      "line_number": 3,
+      "run_time": 3.2
+    },
+    {
+      "id": "./spec/models/post_spec.rb[1:2]",
+      "description": "has many comments",
+      "full_description": "Post has many comments",
+      "status": "passed",
+      "file_path": "./spec/models/post_spec.rb",
+      "line_number": 8,
+      "run_time": 2.1
+    },
+    {
+      "id": "./spec/controllers/users_controller_spec.rb[1:1]",
+      "description": "returns success",
+      "full_description": "GET index returns success",
+      "status": "passed",
+      "file_path": "./spec/controllers/users_controller_spec.rb",
+      "line_number": 3,
+      "run_time": 1.5
+    },
+    {
+      "id": "./spec/controllers/users_controller_spec.rb[1:2]",
+      "description": "creates user",
+      "full_description": "POST create creates user",
+      "status": "passed",
+      "file_path": "./spec/controllers/users_controller_spec.rb",
+      "line_number": 9,
+      "run_time": 0.8
+    },
+    {
+      "id": "./spec/controllers/posts_controller_spec.rb[1:1]",
+      "description": "returns posts",
+      "full_description": "GET index returns posts",
+      "status": "passed",
+      "file_path": "./spec/controllers/posts_controller_spec.rb",
+      "line_number": 3,
+      "run_time": 1.9
+    },
+    {
+      "id": "./spec/services/auth_service_spec.rb[1:1]",
+      "description": "authenticates user",
+      "full_description": "AuthService authenticates user",
+      "status": "passed",
+      "file_path": "./spec/services/auth_service_spec.rb",
+      "line_number": 3,
+      "run_time": 0.7
+    },
+    {
+      "id": "./spec/helpers/application_helper_spec.rb[1:1]",
+      "description": "formats date",
+      "full_description": "ApplicationHelper formats date",
+      "status": "passed",
+      "file_path": "./spec/helpers/application_helper_spec.rb",
+      "line_number": 3,
+      "run_time": 0.5
+    },
+    {
+      "id": "./spec/helpers/application_helper_spec.rb[1:2]",
+      "description": "sanitizes input",
+      "full_description": "ApplicationHelper sanitizes input",
+      "status": "passed",
+      "file_path": "./spec/helpers/application_helper_spec.rb",
+      "line_number": 8,
+      "run_time": 0.5
+    }
+  ],
+  "summary": {
+    "duration": 15.5,
+    "example_count": 10,
+    "failure_count": 0,
+    "pending_count": 0,
+    "errors_outside_of_examples_count": 0
+  },
+  "summary_line": "10 examples, 0 failures"
+}

--- a/spec/split_test_rb/json_parser_spec.rb
+++ b/spec/split_test_rb/json_parser_spec.rb
@@ -1,0 +1,217 @@
+require 'spec_helper'
+
+RSpec.describe SplitTestRb::JsonParser do
+  describe '.parse' do
+    let(:fixture_path) { File.expand_path('../fixtures/sample_rspec.json', __dir__) }
+
+    it 'parses RSpec JSON and extracts file timings' do
+      timings = described_class.parse(fixture_path)
+
+      expect(timings).to be_a(Hash)
+      expect(timings.keys).to contain_exactly(
+        'spec/models/user_spec.rb',
+        'spec/models/post_spec.rb',
+        'spec/controllers/users_controller_spec.rb',
+        'spec/controllers/posts_controller_spec.rb',
+        'spec/services/auth_service_spec.rb',
+        'spec/helpers/application_helper_spec.rb'
+      )
+    end
+
+    it 'aggregates timings for files with multiple examples' do
+      timings = described_class.parse(fixture_path)
+
+      # user_spec.rb has 2 examples: 2.5s + 1.8s = 4.3s
+      expect(timings['spec/models/user_spec.rb']).to be_within(0.001).of(4.3)
+
+      # post_spec.rb has 2 examples: 3.2s + 2.1s = 5.3s
+      expect(timings['spec/models/post_spec.rb']).to be_within(0.001).of(5.3)
+
+      # application_helper_spec.rb has 2 examples: 0.5s + 0.5s = 1.0s
+      expect(timings['spec/helpers/application_helper_spec.rb']).to be_within(0.001).of(1.0)
+
+      # users_controller_spec.rb has 2 examples: 1.5s + 0.8s = 2.3s
+      expect(timings['spec/controllers/users_controller_spec.rb']).to be_within(0.001).of(2.3)
+    end
+
+    it 'handles files with single example' do
+      timings = described_class.parse(fixture_path)
+
+      expect(timings['spec/services/auth_service_spec.rb']).to eq(0.7)
+      expect(timings['spec/controllers/posts_controller_spec.rb']).to eq(1.9)
+    end
+
+    context 'with empty JSON' do
+      it 'returns empty hash' do
+        Tempfile.create(['empty', '.json']) do |file|
+          file.write('{"examples": []}')
+          file.rewind
+
+          timings = described_class.parse(file.path)
+          expect(timings).to eq({})
+        end
+      end
+    end
+
+    context 'with JSON missing examples key' do
+      it 'returns empty hash' do
+        Tempfile.create(['no_examples', '.json']) do |file|
+          file.write('{"version": "3.13.0"}')
+          file.rewind
+
+          timings = described_class.parse(file.path)
+          expect(timings).to eq({})
+        end
+      end
+    end
+
+    context 'when file paths start with ./' do
+      it 'normalizes paths by removing leading ./' do
+        timings = described_class.parse(fixture_path)
+
+        # Verify all keys are normalized (no leading ./)
+        timings.keys.each do |path|
+          expect(path).not_to start_with('./')
+        end
+
+        # Verify we can find files by normalized paths
+        expect(timings['spec/models/user_spec.rb']).to be > 0
+        expect(timings['spec/models/post_spec.rb']).to be > 0
+      end
+    end
+
+    context 'when examples have no file_path' do
+      it 'skips those examples' do
+        Tempfile.create(['no_filepath', '.json']) do |file|
+          json_content = {
+            examples: [
+              { description: 'test 1', run_time: 1.0 },
+              { description: 'test 2', file_path: 'spec/test_spec.rb', run_time: 2.0 }
+            ]
+          }.to_json
+
+          file.write(json_content)
+          file.rewind
+
+          timings = described_class.parse(file.path)
+          expect(timings).to eq('spec/test_spec.rb' => 2.0)
+        end
+      end
+    end
+  end
+
+  describe '.parse_directory' do
+    it 'parses all JSON files in directory' do
+      Dir.mktmpdir do |tmpdir|
+        # Create multiple JSON files
+        File.write(
+          File.join(tmpdir, 'rspec1.json'),
+          { examples: [{ file_path: 'spec/a_spec.rb', run_time: 1.0 }] }.to_json
+        )
+        File.write(
+          File.join(tmpdir, 'rspec2.json'),
+          { examples: [{ file_path: 'spec/b_spec.rb', run_time: 2.0 }] }.to_json
+        )
+
+        timings = described_class.parse_directory(tmpdir)
+
+        expect(timings).to eq(
+          'spec/a_spec.rb' => 1.0,
+          'spec/b_spec.rb' => 2.0
+        )
+      end
+    end
+
+    it 'merges timings from multiple files for the same spec' do
+      Dir.mktmpdir do |tmpdir|
+        # Both JSON files reference the same spec file
+        File.write(
+          File.join(tmpdir, 'rspec1.json'),
+          { examples: [{ file_path: 'spec/a_spec.rb', run_time: 1.0 }] }.to_json
+        )
+        File.write(
+          File.join(tmpdir, 'rspec2.json'),
+          { examples: [{ file_path: 'spec/a_spec.rb', run_time: 2.0 }] }.to_json
+        )
+
+        timings = described_class.parse_directory(tmpdir)
+
+        # Timings should be merged: 1.0 + 2.0 = 3.0
+        expect(timings).to eq('spec/a_spec.rb' => 3.0)
+      end
+    end
+
+    it 'parses JSON files in subdirectories' do
+      Dir.mktmpdir do |tmpdir|
+        subdir = File.join(tmpdir, 'results')
+        FileUtils.mkdir_p(subdir)
+
+        File.write(
+          File.join(subdir, 'rspec.json'),
+          { examples: [{ file_path: 'spec/a_spec.rb', run_time: 1.5 }] }.to_json
+        )
+
+        timings = described_class.parse_directory(tmpdir)
+
+        expect(timings).to eq('spec/a_spec.rb' => 1.5)
+      end
+    end
+  end
+
+  describe '.parse_files' do
+    it 'parses multiple JSON files' do
+      files = []
+      Dir.mktmpdir do |tmpdir|
+        file1 = File.join(tmpdir, 'rspec1.json')
+        file2 = File.join(tmpdir, 'rspec2.json')
+
+        File.write(
+          file1,
+          { examples: [{ file_path: 'spec/a_spec.rb', run_time: 1.0 }] }.to_json
+        )
+        File.write(
+          file2,
+          { examples: [{ file_path: 'spec/b_spec.rb', run_time: 2.0 }] }.to_json
+        )
+
+        files = [file1, file2]
+        timings = described_class.parse_files(files)
+
+        expect(timings).to eq(
+          'spec/a_spec.rb' => 1.0,
+          'spec/b_spec.rb' => 2.0
+        )
+      end
+    end
+
+    it 'skips non-existent files' do
+      Dir.mktmpdir do |tmpdir|
+        existing_file = File.join(tmpdir, 'rspec.json')
+        non_existent_file = File.join(tmpdir, 'does_not_exist.json')
+
+        File.write(
+          existing_file,
+          { examples: [{ file_path: 'spec/a_spec.rb', run_time: 1.0 }] }.to_json
+        )
+
+        timings = described_class.parse_files([existing_file, non_existent_file])
+
+        expect(timings).to eq('spec/a_spec.rb' => 1.0)
+      end
+    end
+  end
+
+  describe '.normalize_path' do
+    it 'removes leading ./ from path' do
+      expect(described_class.normalize_path('./spec/models/user_spec.rb')).to eq('spec/models/user_spec.rb')
+    end
+
+    it 'leaves path unchanged if no leading ./' do
+      expect(described_class.normalize_path('spec/models/user_spec.rb')).to eq('spec/models/user_spec.rb')
+    end
+
+    it 'only removes leading ./ not internal ones' do
+      expect(described_class.normalize_path('./spec/./models/user_spec.rb')).to eq('spec/./models/user_spec.rb')
+    end
+  end
+end

--- a/split-test-rb.gemspec
+++ b/split-test-rb.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |spec|
   spec.version       = '0.1.0'
   spec.authors       = ['Naofumi Fujii']
   spec.summary       = 'Split tests across multiple nodes based on timing data'
-  spec.description   = 'A simple CLI tool to balance RSpec tests across parallel CI nodes using JUnit XML reports'
+  spec.description   = 'A simple CLI tool to balance RSpec tests across parallel CI nodes using test timing data from RSpec JSON or JUnit XML reports'
   spec.homepage      = 'https://github.com/naofumi-fujii/split-test-rb'
   spec.license       = 'MIT'
   spec.required_ruby_version = '>= 3.2.0'


### PR DESCRIPTION
- Implement JsonParser class to parse RSpec JSON output
- Auto-detect format (JSON/XML) based on file extensions in results directory
- Update CLI to support both formats transparently
- Add comprehensive tests for JSON parser
- Update documentation to recommend JSON formatter (no gem required)
- Update gemspec description to mention both formats

This allows users to use RSpec's built-in JSON formatter instead of requiring the rspec_junit_formatter gem, reducing external dependencies.