### PR TITLE
Add version prefix to rspec-results cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,14 +74,15 @@ jobs:
 
     # Restore previous test results for optimal test distribution
     # Priority: 1) Current branch cache, 2) Main branch cache (for first PR run), 3) Any other branch
+    # Cache key version: increment when changing cache format (e.g., JUnit XML -> RSpec JSON)
     - name: Restore previous test results from cache
       uses: actions/cache/restore@v5
       with:
         path: tmp/rspec-results/
-        key: rspec-results-${{ github.ref }}
+        key: rspec-results-v1-${{ github.ref }}
         restore-keys: |
-          rspec-results-refs/heads/main
-          rspec-results-
+          rspec-results-v1-refs/heads/main
+          rspec-results-v1-
 
     - name: Run tests with split-test-rb
       run: |
@@ -129,4 +130,4 @@ jobs:
       uses: actions/cache/save@v5
       with:
         path: tmp/rspec-results/
-        key: rspec-results-${{ github.ref }}
+        key: rspec-results-v1-${{ github.ref }}


### PR DESCRIPTION
## Summary
- キャッシュキーにバージョンプレフィックス `v1-` を追加
- キャッシュフォーマット変更時にバージョン番号を上げることで古いキャッシュを無効化可能に

## Background
PR #47 で JUnit XML から RSpec JSON に変更した際、古いキャッシュ（`rspec-results-refs/heads/main`）が残っていて上書きできなかった。これにより parallel-test でテスト時間データが読み込まれず、すべてのファイルがデフォルト時間（1.0s）で分割されていた。

古いキャッシュは手動で削除済み。

## Test plan
- [ ] CI の parallel-test ジョブで `Files with historical timing` が 0 以上になることを確認
- [ ] main へマージ後、次回 PR でキャッシュが正しく復元されることを確認