### PR TITLE
Add run_id to cache key for automatic cache updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,16 @@ jobs:
         bundler-cache: true
 
     # Restore previous test results for optimal test distribution
-    # Priority: 1) Current branch cache, 2) Main branch cache (for first PR run), 3) Any other branch
-    # Cache key version: increment when changing cache format (e.g., JUnit XML -> RSpec JSON)
+    # Uses prefix matching to find the latest cache from the same branch or main branch
+    # Cache key version: increment when changing cache format
     - name: Restore previous test results from cache
       uses: actions/cache/restore@v5
       with:
         path: tmp/rspec-results/
-        key: rspec-results-v1-${{ github.ref }}
+        key: rspec-results-v1-${{ github.ref }}-${{ github.run_id }}
         restore-keys: |
-          rspec-results-v1-refs/heads/main
-          rspec-results-v1-
+          rspec-results-v1-${{ github.ref }}-
+          rspec-results-v1-refs/heads/main-
 
     - name: Run tests with split-test-rb
       run: |
@@ -130,4 +130,4 @@ jobs:
       uses: actions/cache/save@v5
       with:
         path: tmp/rspec-results/
-        key: rspec-results-v1-${{ github.ref }}
+        key: rspec-results-v1-${{ github.ref }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- キャッシュキーに `run_id` を追加し、毎回新しいキャッシュを作成可能に
- `restore-keys` のプレフィックスマッチングで最新のキャッシュを復元

## Background
GitHub Actions のキャッシュは同じキーで上書きできないため、ブランチ名のみをキーにすると：
- 1回目: キャッシュ保存 ✓
- 2回目以降: 既存キャッシュがあるため保存失敗 ✗

テストファイルが追加/削除されても古いタイミングデータが使われ続ける問題があった。

## Changes
```yaml
# Before
key: rspec-results-v1-${{ github.ref }}

# After
key: rspec-results-v1-${{ github.ref }}-${{ github.run_id }}
restore-keys: |
  rspec-results-v1-${{ github.ref }}-
  rspec-results-v1-refs/heads/main-
```

## Test plan
- [ ] CI が正常に動作することを確認
- [ ] 2回目以降の実行でもキャッシュが正しく更新されることを確認