### PR TITLE
Use Unix timestamp for cache key instead of run_id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: tmp/rspec-results/
-        key: rspec-results-v1-${{ github.ref }}-
+        key: rspec-results-v1-${{ github.ref }}-${{ github.run_id }}
         restore-keys: |
           rspec-results-v1-${{ github.ref }}-
           rspec-results-v1-refs/heads/main-
@@ -133,4 +133,4 @@ jobs:
       uses: actions/cache/save@v5
       with:
         path: tmp/rspec-results/
-        key: rspec-results-v1-${{ github.ref }}-${{ env.TIMESTAMP }}
+        key: rspec-results-v1-${{ github.ref }}-${{ github.run_id }}-${{ env.TIMESTAMP }}


### PR DESCRIPTION
This allows cache to be saved on reruns, since run_id stays the same
but timestamp will be different each time.

https://claude.ai/code/session_01242y9YsXR1k44ECAkaHyi1