### PR TITLE
空ファイルや不正なJSONファイルをスキップする処理を追加

### DIFF
--- a/lib/split_test_rb.rb
+++ b/lib/split_test_rb.rb
@@ -41,11 +41,16 @@ module SplitTestRb
 
       json_paths.each do |json_path|
         next unless File.exist?(json_path)
+        next if File.zero?(json_path)
 
-        file_timings = parse(json_path)
-        file_timings.each do |file, time|
-          timings[file] ||= 0
-          timings[file] += time
+        begin
+          file_timings = parse(json_path)
+          file_timings.each do |file, time|
+            timings[file] ||= 0
+            timings[file] += time
+          end
+        rescue JSON::ParserError => e
+          warn "Warning: Failed to parse #{json_path}: #{e.message}"
         end
       end
 


### PR DESCRIPTION
## Summary
- `parse_files`メソッドで空ファイルをスキップする処理を追加（`File.zero?`でチェック）
- `JSON::ParserError`をキャッチして警告を出力し、処理を継続するように変更
- 上記の動作を確認するテストを追加

## 背景
GitHub ActionsのCIでキャッシュから復元されたRSpec結果JSONファイルが空または破損していた場合、`JSON::ParserError`が発生してテスト分散処理が失敗していました。

```
bundler: failed to load command: split-test-rb
JSON::ParserError: unexpected end of input at line 1 column 1
```

## Test plan
- [x] 既存のテストがパスすることを確認
- [x] 空ファイルをスキップするテストを追加
- [x] 不正なJSONファイルをスキップするテストを追加