### PR TITLE
Fix RuboCop violations

### DIFF
--- a/lib/split_test_rb.rb
+++ b/lib/split_test_rb.rb
@@ -41,7 +41,7 @@ module SplitTestRb
 
       json_paths.each do |json_path|
         next unless File.exist?(json_path)
-        next if File.zero?(json_path)
+        next if File.empty?(json_path)
 
         begin
           file_timings = parse(json_path)

--- a/spec/split_test_rb/json_parser_spec.rb
+++ b/spec/split_test_rb/json_parser_spec.rb
@@ -205,11 +205,11 @@ RSpec.describe SplitTestRb::JsonParser do
 
         File.write(invalid_file, 'invalid json content')
 
-        expect {
+        expect do
           timings = described_class.parse_files([file1, invalid_file])
           expect(timings.keys).to contain_exactly('spec/a_spec.rb')
           expect(timings['spec/a_spec.rb']).to eq(1.0)
-        }.to output(/Warning: Failed to parse.*invalid\.json/).to_stderr
+        end.to output(/Warning: Failed to parse.*invalid\.json/).to_stderr
       end
     end
   end


### PR DESCRIPTION
- Use File.empty? instead of File.zero? (Style/FileEmpty)
- Use do...end instead of {...} for multi-line blocks (Style/BlockDelimiters)

https://claude.ai/code/session_01UQLQizoqv3NvpDq7waVe3U